### PR TITLE
found minor fix, explained in comments

### DIFF
--- a/frontend/market-maven/src/Components/ItemDetails.js
+++ b/frontend/market-maven/src/Components/ItemDetails.js
@@ -1,56 +1,55 @@
-import React from 'react';
-import { useParams , useLocation} from 'react-router-dom';
-import Navbar from './Navbar';
-import data from "../pages/data.json"
+import React, { useState, useEffect } from "react";
+import Navbar from "./Navbar";
+import { useParams } from "react-router-dom";
+import axios from "axios";
 
-const ItemDetails = ({ item, addToCart }) => {
-    console.log(data);
-    const event = data[0];
-  const { id } = useParams();
-  //const { state } = useLocation(); 
-  //const item = state.item;
-  //const item = items.find((item) => item.id === parseInt(id));
-  const handleClick = (name, quantitiy) => {
-    if (quantitiy > 0) {
-      item.addToCart(name);
-      item.setItems(
-        item.items.map((item) =>
-          item.name === name ? { ...item, quantity: item.quantity - 1 } : item
-        )
-      );
-    }
-  };
+const ItemDetails = () => {
+  const [item, setItem] = useState({}); // Initialize item state with an empty object
 
-  const handleAddToCart = () => {
-    addToCart(item.name);
+  // takes the product id from the Link routing as a parameter
+  const params = useParams ();
+
+  // useEffect executse on component mount (no compile errors)
+  useEffect(() => {
+
+    // GET request to fetch the single product
+    const fetchProduct = async () => {
+      const res = await axios.get(`http://localhost:8080/api/products/${params.id}`);
+      console.log(res.data)
+
+      setItem(res.data);
+    };
+
+    fetchProduct()
+  }, []);
+
+  // Handle click event for adding item to cart
+  const handleClick = (name, quantity) => {
+
   };
 
   return (
     <>
-    <Navbar/>
-    <div className='grid grid-cols-2 bg-white'>
-    <div className='object-left h-[600px] w-[600px] bg-white'>
-        <img src={event.image} />
-    </div>
-    <div className=''>
-      <h1 className='text-center text-black'>{event.name}</h1>
-      <h2>{event.cost}</h2>
-      <p className='my-4 p-10 text-left'>{event.description}</p>
-      
-      
-      {/*<button 
-      class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-      onClick={handleAddToCart}>
-        Add to Cart
-  </button>*/}
-      <button 
-        onClick={() => handleClick(item.name, item.quantitiy)}
-        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-      >
-        Add to Cart
-      </button>
-    </div>
-    </div>
+      <Navbar />
+      <div className="grid grid-cols-2 bg-white">
+        <div className="object-left h-[600px] w-[600px] bg-white">
+          {/* Render item image */}
+          <img src={item.pic} alt={item.name} />
+        </div>
+        <div className="">
+          <h1 className="text-center text-black">{item.name}</h1>
+          <h2>{item.cost}</h2>
+          <p className="my-4">{item.description}</p>
+
+          {/* Render Add to Cart button */}
+          <button
+            onClick={() => handleClick(item.name, item.quantity)}
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          >
+            Add to Cart
+          </button>
+        </div>
+      </div>
     </>
   );
 };

--- a/frontend/market-maven/src/pages/Shop.js
+++ b/frontend/market-maven/src/pages/Shop.js
@@ -1,13 +1,30 @@
 import React from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from "react";
 import { Link } from 'react-router-dom';
 import data from './data.json'
 import Item from '../Components/Item';
 import Navbar from '../Components/Navbar';
 
+import axios from 'axios';
+
 const Shop = () => {
   const [items, setItems] = useState(data);
   const [cart, setCart] = useState([]);
+
+  useEffect(() => {
+    const fetchItems = async () => {
+      // const response = await fetch(`/api/products`);
+      const response = await fetch('http://localhost:8080/api/products')
+      const json = await response.json(); // array of objects
+      console.log(json)
+
+      if (response.ok) {
+        setItems(json);
+      }
+    };
+
+    fetchItems();
+  }, []);
 
   const addToCart = (item) => {
     if (cart.map((cartItem) => cartItem[0]).includes(item)) {
@@ -44,9 +61,14 @@ const Shop = () => {
         <Navbar />
         <div className="grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-4 px-2 bg-white">
         {items.map((item) => (
-          <Link key={item.id} to={`/ItemDetails/${item.id}`}>  {/*{`/item/${item.id}`}*/}
+
+          // correct implementation of Link and the to props with its state property
+          // I have no idea why ItemDetails refuses to recieve the state as anything
+          // other than "null", will keep in case we can fix later since this would be
+          // better than just making a GET request for each individal item for their page
+          <Link key={item._id} to={{pathname: `/ItemDetails/${item._id}`, state: item}}>
           <Item
-            key={item.id}
+            key={item._id}
             name={item.name}
             cost={item.cost}
             pic={item.image}


### PR DESCRIPTION
For some inane reason the Link component in Shop.js that routes to individual ItemDetails pages keeps failing to send the `state` property of the `to` prop over to the ItemDetails component, or the ItemDetails component fails to recieve it. Current fix is to just have the ItemDetails component make a GET request with the id parameter from the Link URL.

explained more in the comments and in slack